### PR TITLE
no leading and trailing spaces for signup and change username

### DIFF
--- a/pong/users/serializers.py
+++ b/pong/users/serializers.py
@@ -17,7 +17,7 @@ class NoStripCharField(serializers.CharField):
         return data
 
 class UserSerializer(serializers.ModelSerializer):
-    username = NoStripCharField(required=True, min_length=1, max_length=30)
+    username = NoStripCharField(required=True, min_length=1, max_length=20)
     email = NoStripCharField(required=True)
     password = NoStripCharField(write_only=True, required=True, min_length=8)
 

--- a/pong/users/serializers.py
+++ b/pong/users/serializers.py
@@ -12,10 +12,57 @@ from .models import GameResult, PlayerStats
 import re
 User = get_user_model()
 
+class NoStripCharField(serializers.CharField):
+    def to_internal_value(self, data):
+        return data
+
 class UserSerializer(serializers.ModelSerializer):
+    username = NoStripCharField(required=True, min_length=1, max_length=30)
+    email = NoStripCharField(required=True)
+    password = NoStripCharField(write_only=True, required=True, min_length=8)
+
     class Meta:
         model = User
-        fields = ['id', 'username', 'email', 'online', 'language', 'profile_picture']
+        fields = ['id', 'username', 'email', 'online', 'language', 'profile_picture', 'password']
+
+    def validate_username(self, value):
+        if value != value.strip():
+            raise serializers.ValidationError("Username cannot have leading or trailing spaces.")
+        
+        if not re.match(r'^\w+$', value):
+            raise serializers.ValidationError("Username can only contain letters, numbers, and underscores.")
+        
+        if User.objects.filter(username=value).exists():
+            raise serializers.ValidationError("Username is already taken.")
+        
+        return value
+
+    def validate_email(self, value):
+        if value != value.strip():
+            raise serializers.ValidationError("Email cannot have leading or trailing spaces.")
+        
+        email_regex = r'^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$'
+        if not re.match(email_regex, value):
+            raise serializers.ValidationError("Enter a valid email address.")
+        
+        if User.objects.filter(email=value).exists():
+            raise serializers.ValidationError("Email is already taken.")
+        
+        return value
+
+    def validate_password(self, value):
+        try:
+            validate_password(value)
+        except ValidationError as e:
+            raise serializers.ValidationError(e.messages)
+        return value
+
+    def create(self, validated_data):
+        password = validated_data.pop('password')
+        user = User.objects.create(**validated_data)
+        user.set_password(password)
+        user.save()
+        return user
 
 class FriendSerializer(serializers.ModelSerializer):
     class Meta:
@@ -63,10 +110,14 @@ class PlayerStatsSerializer(serializers.ModelSerializer):
         model = PlayerStats
         fields = ['username', 'profile_picture', 'victories', 'losses', 'online']
 
+
+
 class ChangeUsernameSerializer(serializers.Serializer):
-    new_username = serializers.CharField(required=True, min_length=1, max_length=20)
+    new_username = NoStripCharField(required=True, min_length=1, max_length=20)
 
     def validate_new_username(self, value):
+        if value != value.strip():
+            raise serializers.ValidationError("Username cannot have leading or trailing spaces.")
         if not re.match(r'^\w+$', value):
             raise serializers.ValidationError("Username can only contain letters, numbers, and underscores.")
         if User.objects.filter(username=value).exists():

--- a/pong/users/views.py
+++ b/pong/users/views.py
@@ -45,24 +45,19 @@ def logout(request):
 @api_view(['POST'])
 def signup(request):
     serializer = UserSerializer(data=request.data)
+
     if serializer.is_valid():
-        email = request.data.get('email')
-        if User.objects.filter(email=email).exists():
-            return Response({"error": "Email already taken."}, status=status.HTTP_400_BAD_REQUEST)
-        password = request.data.get('password')
-        if not password:
-            return Response({"error": "Password is required."}, status=status.HTTP_400_BAD_REQUEST)
-        try:
-            validate_password(request.data['password'])
-        except ValidationError as e:
-            return Response({"error": e.messages}, status=status.HTTP_400_BAD_REQUEST)
-        serializer.save()
-        user = User.objects.get(username=request.data['username'])
-        user.set_password(request.data['password']) #hash pass with this function
-        user.save()
+        user = serializer.save()
+        
         PlayerStats.objects.create(user=user)
         token = Token.objects.create(user=user)
-        return Response({'token': token.key, 'user': serializer.data}, status=status.HTTP_201_CREATED)
+        
+        response_data = {
+            'token': token.key,
+            'user': serializer.data
+        }
+        return Response(response_data, status=status.HTTP_201_CREATED)
+
     return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 @api_view(['GET'])


### PR DESCRIPTION
#47 

Please check

1. Signup form
  - Can not signup when username contains spaces before, after or at middle ("elina    ", "    elina", "elina 2")
  - Can not signup when email contains spaces before, after or at middle
  - Can not signup when password contains spaces before, after or at middle
  - Can create up to 20 characters (letters, numbers, underscore) for username
  - Can not create duplicate name
  - Can not create duplicate email
  - Email starts with characters (letters, numbers, and underscores), dots, or hyphens. @ is required. 
  - For email after the "@" - one or more word characters, dots, or hyphens. Requires a literal dot. The domain extension with at least two characters
  - 
2. Change username from account 
- All the validations above for username